### PR TITLE
fix: runtime `renderAsync` errors when sending

### DIFF
--- a/app/api/send/route.tsx
+++ b/app/api/send/route.tsx
@@ -9,8 +9,8 @@ export async function POST() {
     const { data, error } = await resend.emails.send({
       from: 'Acme <onboarding@resend.dev>',
       to: ['delivered@resend.dev'],
-      subject: "Hello world",
-      react: EmailTemplate({ firstName: "John" }) as React.ReactElement,
+      subject: 'Hello world',
+      react: <EmailTemplate firstName="John" />,
     });
 
     if (error) {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "next dev"
   },
   "dependencies": {
+    "@react-email/components": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",


### PR DESCRIPTION
Fixes what https://github.com/resend/resend-node/issues/616 mentions by just adding `@react-email/components` as a dependency. This pull request also changes the sending code to use JSX syntax when instantiating the email template component.

It also updates the `next-env.d.ts` file with the automated changes that Next.js makes by just running `next dev`.